### PR TITLE
Enclose super.getClient() in a try/catch block

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,10 @@ class MitmProxy extends PureProxy {
         if (await this.shouldIntercept(hostname, port, context)) {
             const options = { hostname, port, context }
 
-            let client = await super.getClient(hostname, port, context)
+            let client
+            try {
+                client = await super.getClient(hostname, port, context)
+            } catch (e) {}
 
             const self = this
 
@@ -101,7 +104,12 @@ class MitmProxy extends PureProxy {
             }
         }
         else {
-            return await super.getClient(hostname, port, context)
+            let client
+            try {
+                client = await super.getClient(hostname, port, context)
+            } catch (e) {}
+            
+            return client
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where connection failures (on blocked domains, for example) generate unhandled exceptions.